### PR TITLE
Support for decompressed DCUO packages

### DIFF
--- a/src/Core/Tables/UNameTableItem.cs
+++ b/src/Core/Tables/UNameTableItem.cs
@@ -27,7 +27,24 @@ namespace UELib
 
         public void Deserialize( IUnrealStream stream )
         {
-            Name = stream.ReadText();
+#if DCUO
+            if ( stream.Package.Build == UnrealPackage.GameBuild.BuildName.DCUO )
+            {
+                //DCUO doesn't null terminate name table entries
+                int size = stream.ReadInt32();
+                var strBytes = new byte[size];
+                stream.Read( strBytes, 0, size );
+                if ( stream.BigEndianCode )
+                {
+                    Array.Reverse( strBytes );
+                }
+                Name = System.Text.Encoding.ASCII.GetString( strBytes );
+            }
+            else
+#endif
+            {
+                Name = stream.ReadText();
+            }
             Flags = stream.Version >= QWORDVersion ? stream.ReadUInt64() : stream.ReadUInt32();
 #if DEOBFUSCATE
     // De-obfuscate names that contain unprintable characters!

--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -387,6 +387,12 @@ namespace UELib
                 Tera,
 
                 /// <summary>
+                /// 648/6405
+                /// </summary>
+                [Build( 648, 6405 )]
+                DCUO,
+
+                /// <summary>
                 /// 727/075
                 /// </summary>
                 [Build( 727, 75 )]
@@ -1068,6 +1074,42 @@ namespace UELib
                     }
                 }
             }
+
+#if DCUO
+            if( Build == GameBuild.BuildName.DCUO )
+            {
+                //We need to back up because our package has already been decompressed
+                stream.Position -= 4;
+
+                int unkCount = stream.ReadInt32();
+
+                stream.Skip( 16 * unkCount );
+
+                stream.Skip( 4 );
+
+                if( Version >= 516 )
+                {
+                    int textCount = stream.ReadInt32();
+
+                    var texts = new List<string>();
+                    for( int i = 0; i < textCount; i++ )
+                    {
+                        texts.Add( stream.ReadText() );
+                    }
+                }
+                
+                uint realNameOffset = (uint)stream.Position;
+
+                System.Diagnostics.Debug.Assert( realNameOffset <= _TablesData.NamesOffset, "realNameOffset is > the parsed name offset for a DCUO package, we don't know where to go now!" );
+
+                uint offsetDif = _TablesData.NamesOffset - realNameOffset;
+
+                //The offsets parsed above are off, maybe due to decompression?
+                _TablesData.NamesOffset -= offsetDif;
+                _TablesData.ImportsOffset -= offsetDif;
+                _TablesData.ExportsOffset -= offsetDif;
+            }
+#endif
 
             // Read the name table
             if( _TablesData.NamesCount > 0 )


### PR DESCRIPTION
This should allow the Unreal-Library to read DC Universe Online packages for the current release after they have been decompressed with Glidor's tool.

I had to do some manual offset adjustments which I'm assuming is due to the decompression process but I'm not sure. Also the name table entries are read slightly different than normal strings. To keep that code out of the more highly used ReadText() I just added it directly to the NameEntry deserialization but it might be cleaner with a param for ReadText to handle that (or a different function, ReadString32()?)