### PR TITLE
Support for loading decompressed Arkham City/Origins/Knight packages

### DIFF
--- a/src/Core/Tables/UExportTableItem.cs
+++ b/src/Core/Tables/UExportTableItem.cs
@@ -96,9 +96,10 @@ namespace UELib
 #if BATMAN
             if (stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman2 ||
                 stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman3 ||
+                stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman3MP ||
                 stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman4)
             {
-                var unk = stream.ReadInt32();
+                stream.Skip( sizeof(int) );
             }
 #endif
 

--- a/src/Core/Tables/UExportTableItem.cs
+++ b/src/Core/Tables/UExportTableItem.cs
@@ -93,6 +93,15 @@ namespace UELib
                 ArchetypeIndex = stream.ReadInt32();
             }
 
+#if BATMAN
+            if (stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman2 ||
+                stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman3 ||
+                stream.Package.Build == UnrealPackage.GameBuild.BuildName.Batman4)
+            {
+                var unk = stream.ReadInt32();
+            }
+#endif
+
             _ObjectFlagsOffset = stream.Position;
             ObjectFlags = stream.ReadUInt32();
             if( stream.Version >= VObjectFlagsToULONG

--- a/src/Eliot.UELib.csproj
+++ b/src/Eliot.UELib.csproj
@@ -41,7 +41,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;DECOMPILE SWAT4 UNREAL2 INFINITYBLADE BORDERLANDS2 GOW2 DEBUG_TEST APB SPECIALFORCE2 XIII SINGULARITY THIEFDEADLYSHADOWS BORDERLANDS MIRRORSEDGE BIOSHOCK HAWKEN UT DISHONORED REMEMBERME ALPHAPROTOCOL VANGUARD TERA MKKE TRANSFORMERS XCOM2 BATMAN</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Eliot.UELib.csproj
+++ b/src/Eliot.UELib.csproj
@@ -43,7 +43,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;DECOMPILE SWAT4 UNREAL2 INFINITYBLADE BORDERLANDS2 GOW2 DEBUG_TEST APB SPECIALFORCE2 XIII SINGULARITY THIEFDEADLYSHADOWS BORDERLANDS MIRRORSEDGE BIOSHOCK HAWKEN UT DISHONORED REMEMBERME ALPHAPROTOCOL VANGUARD TERA MKKE TRANSFORMERS XCOM2</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DECOMPILE SWAT4 UNREAL2 INFINITYBLADE BORDERLANDS2 GOW2 DEBUG_TEST APB SPECIALFORCE2 XIII SINGULARITY THIEFDEADLYSHADOWS BORDERLANDS MIRRORSEDGE BIOSHOCK HAWKEN UT DISHONORED REMEMBERME ALPHAPROTOCOL VANGUARD TERA MKKE TRANSFORMERS XCOM2 BATMAN</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -250,7 +250,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_BuildVersioningStyle="None.None.Increment.None" />
+      <UserProperties BuildVersion_BuildVersioningStyle="None.None.Increment.None" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -487,6 +487,12 @@ namespace UELib
                 Batman3,
 
                 /// <summary>
+                /// 807/104
+                /// </summary>
+                [Build(807, 104)]
+                Batman3MP,
+
+                /// <summary>
                 /// 863/32995
                 /// </summary>
                 [Build(863, 32995)]

--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -472,7 +472,25 @@ namespace UELib
                 /// 845/120
                 /// </summary>
                 [Build(845, 120)]
-                XCOM2WotC
+                XCOM2WotC,
+
+                /// <summary>
+                /// 805/101
+                /// </summary>
+                [Build(805, 101)]
+                Batman2,
+
+                /// <summary>
+                /// 807/138
+                /// </summary>
+                [Build(807, 138)]
+                Batman3,
+
+                /// <summary>
+                /// 863/32995
+                /// </summary>
+                [Build(863, 32995)]
+                Batman4,
             }
 
             public BuildName Name


### PR DESCRIPTION
The Arkham games (excepting Asylum) also use customized property serialization, which I haven't touched on yet. Not sure how cleanly that would integrate into your current codebase.