### PR TITLE
Fix unrecognized console package serialization

### DIFF
--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -632,6 +632,13 @@ namespace UELib
 
             public GameBuild(UnrealPackage package)
             {
+                // If UE Explorer's PlatformMenuItem is equal to "Console", set ConsoleCooked flag.
+                // This is required for correct serialization of unrecognized Console packages
+                if (UnrealConfig.Platform == UnrealConfig.CookedPlatform.Console)
+                {
+                    Flags |= BuildFlags.ConsoleCooked;
+                }
+
                 var buildInfo = FindBuildInfo(package, out var buildAttribute);
                 if (buildInfo == null)
                 {


### PR DESCRIPTION
This check was present in earlier versions of UELib, but seems to have been lost in the latest version. Without it, all unrecognized packages are treated as PC-cooked regardless of the user's chosen platform override