### PR TITLE
Fix for UObject recreating the object buffer while one still exists

### DIFF
--- a/src/Core/Classes/UObject.cs
+++ b/src/Core/Classes/UObject.cs
@@ -197,7 +197,8 @@ namespace UELib.Core
         internal void EnsureBuffer()
         {
             //Console.WriteLine( "Ensure buffer for {0}", (string)this );
-            InitBuffer();
+            if (_Buffer == null)
+                InitBuffer();
         }
 
         internal void MaybeDisposeBuffer()


### PR DESCRIPTION
Currently, `UObject.EnsureBuffer()` always creates a new buffer, even if one already exists. By proxy, this also creates a new `BinaryMetaData`, but doesn't assign it to `UObject`.

As a result, any fields recorded after calling this method will not be visible in UE Explorer's View Buffer. This can also screw up any tool that relies on the binary meta data.

As far as I can tell, this only happens for objects with bytecode, in packages before `v639`, when it can't just skip past the bytecode.