### PR TITLE
Fix for UStaticMeshComponent stub extending UModelComponent instead of UMeshComponent

### DIFF
--- a/src/Engine/Classes/UMeshComponent.cs
+++ b/src/Engine/Classes/UMeshComponent.cs
@@ -25,7 +25,7 @@ namespace UELib.Engine
     /// </summary>
     [UnrealRegisterClass]
     [BuildGeneration(BuildGeneration.UE3)]
-    public class UStaticMeshComponent : UModelComponent
+    public class UStaticMeshComponent : UMeshComponent
     {
     }
 }


### PR DESCRIPTION
I'm guessing this is a typo - since it causes an exception by hitting the end of the stream on `UModelComponent.Deserialize`:

![image](https://github.com/EliotVU/Unreal-Library/assets/69184314/2f7b0be0-ebb6-46a8-abca-b7631e4782cd)

That said, there is *something* there at the end of the stream, after `defaultproperties` ... but it doesn't seem like it's anything from `UModelComponent`.