### PR TITLE
Fix RSS property deserialization

### DIFF
--- a/src/Core/Classes/UDefaultProperty.cs
+++ b/src/Core/Classes/UDefaultProperty.cs
@@ -499,7 +499,7 @@ namespace UELib.Core
                     break;
 
                 case PropertyType.ByteProperty:
-                    if (_Buffer.Version >= (uint)PackageObjectLegacyVersion.EnumNameAddedToBytePropertyTag)
+                    if (_Buffer.Version >= (uint)PackageObjectLegacyVersion.EnumNameAddedToBytePropertyTag && _Buffer.Package.Build.Generation != BuildGeneration.RSS)
                     {
                         _Buffer.Read(out _TypeData.EnumName);
                         Record(nameof(_TypeData.EnumName), _TypeData.EnumName);


### PR DESCRIPTION
Tested with Batman2, should no longer throw out of range exceptions midway through property deserialization