### PR TITLE
Replace AddClassType->TryAddClassType

### DIFF
--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -2162,7 +2162,7 @@ namespace UELib
             foreach (var exportedType in exportedTypes)
             {
                 object[] attributes = exportedType.GetCustomAttributes(typeof(UnrealRegisterClassAttribute), false);
-                if (attributes.Length == 1) AddClassType(exportedType.Name.Substring(1), exportedType);
+                if (attributes.Length == 1) TryAddClassType(exportedType.Name.Substring(1), exportedType);
             }
         }
 
@@ -2238,13 +2238,13 @@ namespace UELib
         [Obsolete]
         public void RegisterClass(string className, Type classObject)
         {
-            AddClassType(className, classObject);
+            TryAddClassType(className, classObject);
         }
 
         [PublicAPI]
-        public void AddClassType(string className, Type classObject)
+        public bool TryAddClassType(string className, Type classObject)
         {
-            _ClassTypes.Add(className.ToLower(), classObject);
+            return _ClassTypes.TryAdd(className.ToLower(), classObject);
         }
 
         [PublicAPI]

--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -2162,7 +2162,7 @@ namespace UELib
             foreach (var exportedType in exportedTypes)
             {
                 object[] attributes = exportedType.GetCustomAttributes(typeof(UnrealRegisterClassAttribute), false);
-                if (attributes.Length == 1) TryAddClassType(exportedType.Name.Substring(1), exportedType);
+                if (attributes.Length == 1) AddClassType(exportedType.Name.Substring(1), exportedType);
             }
         }
 
@@ -2238,13 +2238,13 @@ namespace UELib
         [Obsolete]
         public void RegisterClass(string className, Type classObject)
         {
-            TryAddClassType(className, classObject);
+            AddClassType(className, classObject);
         }
 
         [PublicAPI]
-        public bool TryAddClassType(string className, Type classObject)
+        public void AddClassType(string className, Type classObject)
         {
-            return _ClassTypes.TryAdd(className.ToLower(), classObject);
+            _ClassTypes[className.ToLower()] = classObject;
         }
 
         [PublicAPI]


### PR DESCRIPTION
To override a built-in class type with their own, a user has to call `AddClassType()` manually. Unfortunately, this causes `InitializePackage()` to fail when used with `InitFlags.RegisterClasses`. An option is to simply not pass RegisterClasses, but this way all other class types are still registered automatically