### PR TITLE
Fix RSSContextToken in BM1

### DIFF
--- a/src/Core/Classes/UDefaultProperty.cs
+++ b/src/Core/Classes/UDefaultProperty.cs
@@ -314,7 +314,7 @@ namespace UELib.Core
                 return DeserializeTagUE1();
             }
 #if BATMAN
-            if (_Buffer.Package.Build == BuildGeneration.RSS)
+            if (_Buffer.Package.Build == BuildGeneration.RSS && _Buffer.LicenseeVersion > 21)
             {
                 return DeserializeTagByOffset();
             }
@@ -501,7 +501,7 @@ namespace UELib.Core
                 case PropertyType.ByteProperty:
                     if (_Buffer.Version >= (uint)PackageObjectLegacyVersion.EnumNameAddedToBytePropertyTag
 #if BATMAN
-                        && _Buffer.Package.Build.Generation != BuildGeneration.RSS
+                        && (_Buffer.Package.Build.Generation != BuildGeneration.RSS || _Buffer.LicenseeVersion <= 21)
 #endif
                        )
                     {

--- a/src/Core/Tables/UExportTableItem.cs
+++ b/src/Core/Tables/UExportTableItem.cs
@@ -173,7 +173,7 @@ namespace UELib
                 _ArchetypeIndex = stream.ReadInt32();
             }
 #if BATMAN
-            if (stream.Package.Build == BuildGeneration.RSS)
+            if (stream.Package.Build == BuildGeneration.RSS && stream.LicenseeVersion > 21)
             {
                 stream.Skip(sizeof(int));
             }

--- a/src/UnrealPackage.cs
+++ b/src/UnrealPackage.cs
@@ -519,7 +519,7 @@ namespace UELib
                 /// 
                 /// 576/021 (Missing most changes guarded by <see cref="BuildGeneration.RSS"/>)
                 /// </summary>
-                [Build(576, 21)] [BuildEngineBranch(typeof(EngineBranchRSS))]
+                [Build(576, 21, BuildGeneration.RSS)] [BuildEngineBranch(typeof(EngineBranchRSS))]
                 Batman1,
 
                 /// <summary>


### PR DESCRIPTION
Looks like 0x50 was used back in Asylum too. Most functions already decompile fine but this should fix the last few that don't.