### PR TITLE
Improve Splinter Cell Blacklist (Lead Engine) support

### DIFF
--- a/src/Core/Classes/UClass.cs
+++ b/src/Core/Classes/UClass.cs
@@ -196,6 +196,12 @@ namespace UELib.Core
                 goto skipClassGuid;
             }
 #endif
+#if LEAD
+            if (Package.Build == BuildGeneration.Lead)
+            {
+                goto skipClassGuid;
+            }
+#endif
             if (_Buffer.Version >= (uint)PackageObjectLegacyVersion.ClassGuidDeprecated)
             {
                 if (_Buffer.Version < (uint)PackageObjectLegacyVersion.ClassPlatformFlagsDeprecated)
@@ -218,6 +224,34 @@ namespace UELib.Core
             }
 #endif
         skipClassGuid:
+
+#if LEAD
+            if (Package.Build == BuildGeneration.Lead)
+            {
+                var unk_0 = _Buffer.ReadIndex();
+                Record(nameof(unk_0), unk_0);
+
+                for (int i = 0; i < unk_0; i++) {
+                    var objIdx = _Buffer.ReadObjectIndex();
+                    var prop1 = _Buffer.ReadUInt32();
+                    var prop2 = _Buffer.ReadUInt32();
+
+                    Record("Lead:Unk_0", objIdx + ":" + prop1.ToString() + ":" + prop2.ToString());
+                    Console.WriteLine(Package.GetIndexObjectName(objIdx) + " " + prop1.ToString() + " " + prop2.ToString());
+                }
+
+                ClassGroups = DeserializeGroup("ClassGroups");
+
+                var unk_1 = _Buffer.ReadObjectIndex();
+                var unk_2 = _Buffer.ReadUInt32();
+
+                DeserializeGroup("UnknownGroup");
+
+                DeserializeProperties(_Buffer);
+
+                return;
+            }
+#endif
 
             if (_Buffer.Version < (uint)PackageObjectLegacyVersion.ClassDependenciesDeprecated)
             {

--- a/src/Core/Classes/UStruct.cs
+++ b/src/Core/Classes/UStruct.cs
@@ -224,6 +224,13 @@ namespace UELib.Core
                 Record(nameof(CppText), CppText);
             }
 #endif
+#if LEAD
+            if (Package.Build == BuildGeneration.Lead)
+            {
+                var ObjIndex = _Buffer.ReadIndex();
+                string SomeFStr = _Buffer.ReadString();
+            }
+#endif
         serializeByteCode:
             ByteScriptSize = _Buffer.ReadInt32();
             Record(nameof(ByteScriptSize), ByteScriptSize);

--- a/src/Core/Tokens/OtherTokens.cs
+++ b/src/Core/Tokens/OtherTokens.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using UELib.Annotations;
+using UELib.Branch.UE2.Lead;
 using UELib.ObjectModel.Annotations;
 using UELib.Tokens;
 
@@ -333,7 +334,7 @@ namespace UELib.Core
 #if UNREAL2
                     // FIXME: Is this a legacy feature or U2 specific?
                     // Also in RSRS, and GBX engine
-                    if (stream.Package.Build == UnrealPackage.GameBuild.BuildName.Unreal2XMP)
+                    if (stream.Package.Build == UnrealPackage.GameBuild.BuildName.Unreal2XMP || stream.Package.Build == BuildGeneration.Lead)
                     {
                         OpCodeText = stream.ReadAnsiNullString();
                         Decompiler.AlignSize(OpCodeText.Length + 1);


### PR DESCRIPTION
Couldn't figure out what some of the variables were for yet but this improves the explorer immensly and makes it quite usable. There is much fewer errors parsing classes/methods now, atleast for Echelon.u 