### PR TITLE
Fix UE3 operator precedence + switch-break if/else decompilation

### DIFF
--- a/src/Core/Tokens/FunctionTokens.cs
+++ b/src/Core/Tokens/FunctionTokens.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -39,26 +39,52 @@ namespace UELib.Core
 #pragma warning restore 642
                 }
 
-                private static string PrecedenceToken(Token t)
+                private static byte GetInfixOperPrecedence(Token t)
+                {
+                    switch (t)
+                    {
+                        case NativeFunctionToken token when token.NativeItem.Type == FunctionType.Operator:
+                            return token.NativeItem.OperPrecedence;
+
+                        case FinalFunctionToken token when token.Function.IsOperator()
+                                                            && !token.Function.IsPre()
+                                                            && !token.Function.IsPost():
+                            return token.Function.OperPrecedence;
+
+                        default:
+                            return 0;
+                    }
+                }
+
+                private static string PrecedenceToken(Token t, byte parentPrecedence)
                 {
                     if (!(t is FunctionToken))
                         return t.Decompile();
 
-                    // Always add ( and ) unless the conditions below are not met, in case of a VirtualFunctionCall.
-                    var addParenthesis = true;
-                    switch (t)
-                    {
-                        case NativeFunctionToken token:
-                            addParenthesis = token.NativeItem.Type == FunctionType.Operator;
-                            break;
-                        case FinalFunctionToken token:
-                            addParenthesis = token.Function.IsOperator();
-                            break;
-                    }
+                    byte childPrecedence = GetInfixOperPrecedence(t);
+                    if (childPrecedence == 0)
+                        return t.Decompile();
 
-                    return addParenthesis 
-                        ? $"({t.Decompile()})" 
+                    return childPrecedence > parentPrecedence
+                        ? $"({t.Decompile()})"
                         : t.Decompile();
+                }
+
+                private static bool UnaryOperandNeedsParentheses(Token t)
+                {
+                    return t switch
+                    {
+                        NativeFunctionToken { NativeItem.Type: FunctionType.Operator or FunctionType.Function } => true,
+                        FinalFunctionToken { Function: var function } when function.IsOperator() => true,
+                        _ => GetInfixOperPrecedence(t) > 0
+                    };
+                }
+
+                private static string DecompileUnaryOperand(Token t)
+                {
+                    return UnaryOperandNeedsParentheses(t)
+                        ? $"({t.Decompile()})"
+                        : PrecedenceToken(t, 0);
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -70,7 +96,8 @@ namespace UELib.Core
 
                 protected string DecompilePreOperator(string operatorName)
                 {
-                    string operand = DecompileNext();
+                    var operandToken = NextToken();
+                    string operand = DecompileUnaryOperand(operandToken);
                     AssertSkipCurrentToken<EndFunctionParmsToken>();
 
                     // Only space out if we have a non-symbol operator name.
@@ -79,17 +106,18 @@ namespace UELib.Core
                         : $"{operatorName}{operand}";
                 }
 
-                protected string DecompileOperator(string operatorName)
+                protected string DecompileOperator(string operatorName, byte operPrecedence = byte.MaxValue)
                 {
                     var output =
-                        $"{PrecedenceToken(NextToken())} {operatorName} {PrecedenceToken(NextToken())}";
+                        $"{PrecedenceToken(NextToken(), operPrecedence)} {operatorName} {PrecedenceToken(NextToken(), operPrecedence)}";
                     AssertSkipCurrentToken<EndFunctionParmsToken>();
                     return output;
                 }
 
                 protected string DecompilePostOperator(string operatorName)
                 {
-                    string operand = DecompileNext();
+                    var operandToken = NextToken();
+                    string operand = DecompileUnaryOperand(operandToken);
                     AssertSkipCurrentToken<EndFunctionParmsToken>();
 
                     // Only space out if we have a non-symbol operator name.
@@ -181,15 +209,15 @@ namespace UELib.Core
                     // Support for non native operators.
                     if (Function.IsPost())
                     {
-                        output = DecompilePreOperator(Function.FriendlyName);
+                        output = DecompilePostOperator(Function.FriendlyName);
                     }
                     else if (Function.IsPre())
                     {
-                        output = DecompilePostOperator(Function.FriendlyName);
+                        output = DecompilePreOperator(Function.FriendlyName);
                     }
                     else if (Function.IsOperator())
                     {
-                        output = DecompileOperator(Function.FriendlyName);
+                        output = DecompileOperator(Function.FriendlyName, Function.OperPrecedence);
                     }
                     else
                     {
@@ -327,7 +355,7 @@ namespace UELib.Core
                             break;
 
                         case FunctionType.Operator:
-                            output = DecompileOperator(NativeItem.Name);
+                            output = DecompileOperator(NativeItem.Name, NativeItem.OperPrecedence);
                             break;
 
                         case FunctionType.PostOperator:

--- a/src/Core/Tokens/JumpTokens.cs
+++ b/src/Core/Tokens/JumpTokens.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UELib.Branch;
 using UELib.ObjectModel.Annotations;
@@ -421,7 +421,10 @@ namespace UELib.Core
                                 ifEndJump.MarkedAsSwitchBreak = true;
                             }
                             else if (elseStartToken.Position == CodeOffset &&
-                                     ifEndJump.CodeOffset != elseStartToken.Position)
+                                     ifEndJump.CodeOffset != elseStartToken.Position &&
+                                     ifEndJump.CodeOffset > elseStartToken.Position &&
+                                     !ifEndJump.MarkedAsSwitchBreak &&
+                                     !HasInnerJumpToOffset(CodeOffset, i))
                             {
                                 // Most likely an if-else, mark it as such and let the rest of the logic figure it out further
                                 int begin = Position;
@@ -455,6 +458,21 @@ namespace UELib.Core
                         Position, CodeOffset, this
                     );
                     return output;
+                }
+
+                private bool HasInnerJumpToOffset(int targetOffset, int elseStartTokenIndex)
+                {
+                    int startIndex = Decompiler.DeserializedTokens.IndexOf(this) + 1;
+                    for (int tokenIndex = startIndex; tokenIndex < elseStartTokenIndex; ++tokenIndex)
+                    {
+                        if (Decompiler.DeserializedTokens[tokenIndex] is JumpToken jump
+                            && jump.CodeOffset == targetOffset)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
                 }
             }
 


### PR DESCRIPTION
Hi! While reviewing Mirror's Edge UnrealScript functions I noticed a few inconsistencies. This PR addresses the following:

### 1. Fixed incorrect parentheses when decompiling unary ! applied to compound expressions.

E.g. Current behaviour decompiled the `MoveActionHint` line below to `(!(Hint == MAH_Left) || (Hint == MAH_Right))`, which would disallow right dodge jumps. In-game dodge jumps definitely work in both directions.

```unrealscript
function bool CanDoMove()
{
    if(!PawnOwner.bMoveActionMax)
    {
        return false;
    }
    if(PawnOwner.bUncontrolledSlide)
    {
        return false;
    }
    if(!(int(PawnOwner.MoveActionHint) == int(1)) || int(PawnOwner.MoveActionHint) == int(2))
    {
        return false;
    }
    if(int(PawnOwner.GetWeaponType()) == int(1))
    {
        return false;
    }
    return super(TdMove).CanDoMove();
}
```

The fixes in this PR correct the issue:

```unrealscript
function bool CanDoMove()
{
    if(!PawnOwner.bMoveActionMax)
    {
        return false;
    }
    if(PawnOwner.bUncontrolledSlide)
    {
        return false;
    }
    if(!(int(PawnOwner.MoveActionHint) == int(1) || int(PawnOwner.MoveActionHint) == int(2)))
    {
        return false;
    }
    if(int(PawnOwner.GetWeaponType()) == int(1))
    {
        return false;
    }
    return super(TdMove).CanDoMove();
}
```


### 2. Fixed an issue where if/else blocks could be detected incorrectly if a switch break inside an if body shared a merge label with the if's false branch. 

E.g. Current behaviour produces extra else blocks and !MISMATCHING REMOVE artifacts.:

```unrealscript
if(bInitialActivation)
{
    bBlockAttractMode = false;
    GetTdInteraction().ClearUIInputBlocks();
    if(!GameDataStore.bSkipRestoreScenes)
    {
        GameUISceneClient(SceneClient).RestoreMenuProgression(self);            
    }
    else
    {
        if(int(GameDataStore.RebootReason) != int(0))
        {
            switch(GameDataStore.RebootReason)
            {
                case 2:
                case 1:
                    OpenMessageBox(RebootReasonSigninChangeTitle_MsgBoxInit);
                    break;
                default:
                    break;
            }
        }
        else
        {
        }
    }/* !MISMATCHING REMOVE, tried If got Type:Else Position:0x0FA! */
}/* !MISMATCHING REMOVE, tried Else got Type:If Position:0x0A2! */
```

After the fix:

```unrealscript
if(bInitialActivation)
{
    bBlockAttractMode = false;
    GetTdInteraction().ClearUIInputBlocks();
    if(!GameDataStore.bSkipRestoreScenes)
    {
        GameUISceneClient(SceneClient).RestoreMenuProgression(self);            
    }
    else
    {
        if(int(GameDataStore.RebootReason) != int(0))
        {
            switch(GameDataStore.RebootReason)
            {
                case 2:
                case 1:
                    OpenMessageBox(RebootReasonSigninChangeTitle_MsgBoxInit);
                    break;
                default:
                    break;
            }
        }
    }
}
```

I've only validated these changes against Mirror's Edge packages, though it should address these issues globally.